### PR TITLE
Disable warnings_as_errors

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,7 +1,8 @@
 {erl_first_files, ["src/gen_nb_server.erl", "src/riak_core_gen_server.erl",
 		   "src/riak_core_stat_xform"]}.
 %{cover_enabled, true}.
-{erl_opts, [warnings_as_errors, {parse_transform, lager_transform},
+{erl_opts, [{parse_transform, lager_transform},
+            %% warnings_as_errors,
             debug_info, {platform_define, "^[0-9]+", namespaced_types},
             {platform_define, "18", old_rand},
             {platform_define, "17", old_rand},


### PR DESCRIPTION
This is a bit of a blocker when trying to use this fork in an Elixir project using Elixir 1.6 and Erlang/OTP 20.